### PR TITLE
Add global indices to nodes and rename types

### DIFF
--- a/molalignlib/alignment.f90
+++ b/molalignlib/alignment.f90
@@ -36,7 +36,7 @@ subroutine molecule_align( mol1, mol2, coords2)
    type(mol_type), intent(in) :: mol1, mol2
    real(rk), dimension(:,:), allocatable, intent(out) :: coords2
    ! Local variables
-   type(partitionarray_t) :: eltypes
+   type(partition_t) :: eltypes
    real(rk) :: center1(3), center2(3), rotquat(4)
    real(rk), dimension(:,:), allocatable :: coords1
    real(rk), dimension(:), allocatable :: weights1, weights2

--- a/molalignlib/assignment.f90
+++ b/molalignlib/assignment.f90
@@ -37,7 +37,7 @@ contains
 subroutine assign_atoms_nearest( eltypes, coords1, coords2, atomperm)
 ! Find best correspondence between points sets with fixed orientation
 
-   type(partitionarray_t), target, intent(in) :: eltypes
+   type(partition_t), target, intent(in) :: eltypes
    real(rk), dimension(:,:), intent(in) :: coords1, coords2
    integer, dimension(:), intent(out) :: atomperm
    ! Local variables
@@ -62,7 +62,7 @@ end subroutine
 subroutine assign_atoms_pruned( eltypes, coords1, coords2, prunes, atomperm)
 ! Find best correspondence between points sets with fixed orientation
 
-   type(partitionarray_t), target, intent(in) :: eltypes
+   type(partition_t), target, intent(in) :: eltypes
    real(rk), dimension(:,:), intent(in) :: coords1, coords2
    type(bool_matrix), dimension(:), intent(in) :: prunes
    integer, dimension(:), intent(out) :: atomperm
@@ -87,7 +87,7 @@ end subroutine
 subroutine assign_atoms( eltypes, coords1, coords2, atomperm, dist)
 ! Find best correspondence between points sets with fixed orientation
 
-   type(partitionarray_t), intent(in) :: eltypes
+   type(partition_t), intent(in) :: eltypes
    real(rk), dimension(:,:), intent(in) :: coords1, coords2
    integer, dimension(:), intent(out) :: atomperm
    real(rk), intent(out) :: dist
@@ -107,7 +107,7 @@ end subroutine
 subroutine assign_atoms_biased( eltypes, coords1, coords2, biases, atomperm)
 ! Find best correspondence between points sets with fixed orientation
 
-   type(partitionarray_t), intent(in) :: eltypes
+   type(partition_t), intent(in) :: eltypes
    real(rk), dimension(:,:), intent(in) :: coords1, coords2
    type(int_matrix), dimension(:), intent(in) :: biases
    integer, dimension(:), intent(out) :: atomperm
@@ -126,7 +126,7 @@ subroutine assign_atoms_biased( eltypes, coords1, coords2, biases, atomperm)
 end subroutine
 
 subroutine solve_lap(part, p, q, perm, dist)
-   type(partarray_t), intent(in) :: part
+   type(partition_part_t), intent(in) :: part
    real(rk), dimension(:,:), intent(in) :: p, q
    integer, dimension(:), intent(out) :: perm
    real(rk), intent(out) :: dist
@@ -146,7 +146,7 @@ subroutine solve_lap(part, p, q, perm, dist)
 end subroutine
 
 subroutine solve_lap_biased(part, p, q, biases, perm, dist)
-   type(partarray_t), intent(in) :: part
+   type(partition_part_t), intent(in) :: part
    real(rk), dimension(:,:), intent(in) :: p, q
    integer, dimension(:,:), intent(in) :: biases
    integer, dimension(:), intent(out) :: perm

--- a/molalignlib/biasing.f90
+++ b/molalignlib/biasing.f90
@@ -30,11 +30,11 @@ contains
 subroutine compute_mna_biases(mol1, mol2, eltypes, biases)
 ! Iteratively compute MNA types
    type(mol_type), intent(in) :: mol1, mol2
-   type(partitionarray_t), intent(in) :: eltypes
+   type(partition_t), intent(in) :: eltypes
    type(int_matrix), dimension(:), allocatable, intent(out) :: biases
    ! Local variables
    type(part_node_t), pointer :: root_part
-   type(split_node_t), pointer :: mnachain
+   type(chain_node_t), pointer :: mnachain
    integer :: h, i, j, iatom, jatom
    integer :: num_splits
 !   integer :: link_idx
@@ -47,14 +47,13 @@ subroutine compute_mna_biases(mol1, mol2, eltypes, biases)
    end do
 
    ! Initialize mna chain with element types
-   call init_chain_from_partarray( eltypes, mnachain, root_part)
+   call init_chain_from_partition( eltypes, mnachain, root_part)
 
 !   link_idx = 0
    do
 
 !      write(stderr, *)
 !      write(stderr, '(a)') repeat('-- link_idx '//str(link_idx)//' --', 6)
-!      call print_link(mnachain%last_link)
 
       ! Call compute_nextlevel_mnas and get the number of splits
       call compute_nextlevel_mnas(mol1, mol2, mnachain, num_splits)
@@ -88,7 +87,6 @@ subroutine compute_mna_biases(mol1, mol2, eltypes, biases)
 !      end do
 !   end do
 
-!   call print_chain(mnachain)
    call delete_chain(mnachain)  ! Cleanup
    call delete_part_tree(root_part)  ! Cleanup
 end subroutine

--- a/molalignlib/eltype_compute.f90
+++ b/molalignlib/eltype_compute.f90
@@ -49,7 +49,7 @@ end function
 subroutine set_eltypes(atoms1, atoms2, eltypes)
 ! Partition atoms by atomic number and label using arrays directly
    type(atom_type), dimension(:), intent(in) :: atoms1, atoms2
-   type(partitionarray_t), intent(out) :: eltypes
+   type(partition_t), intent(out) :: eltypes
    ! Local variables
    type(atomtype_table) :: atomtypetable
    integer :: i, num_atoms1, num_atoms2
@@ -113,7 +113,7 @@ subroutine set_eltypes(atoms1, atoms2, eltypes)
       itemdir2_temp(i) = part_index
    end do
 
-   ! Now build the final partitionarray_t structure
+   ! Now build the final partition_t structure
    eltypes%num_parts = current_part
    allocate(eltypes%parts(eltypes%num_parts))
    allocate(eltypes%itemdir1(num_atoms1))

--- a/molalignlib/lcrs_tree.f90
+++ b/molalignlib/lcrs_tree.f90
@@ -6,34 +6,22 @@ private
 ! Item node
 type, public :: item_node_t
    integer :: value
+   integer :: global_index
    type(item_node_t), pointer :: next_item
-end type
-
-! LCRS branch node
-type, public :: split_node_t
-   integer :: num_links
-   integer :: num_children
-   integer :: tot_items1
-   integer :: tot_items2
-   type(split_node_t), pointer :: parent_branch
-   type(split_node_t), pointer :: first_child_branch
-   type(split_node_t), pointer :: last_child_branch
-   type(split_node_t), pointer :: next_sibling_branch
-   type(link_node_t), pointer :: first_link
-   type(link_node_t), pointer :: last_link
-   type(part_node_t), pointer :: split_part
 end type
 
 ! Part reference node
 type, public :: partref_node_t
+   integer :: global_index
    type(part_node_t), pointer :: part
    type(partref_node_t), pointer :: nextref
-   type(link_node_t), pointer :: parent_link
 end type
 
 ! Link node
 type, public :: link_node_t
    integer :: num_parts
+   integer :: global_index
+   integer, pointer :: total_partrefs => null()
    type(link_node_t), pointer :: next_link
    type(partref_node_t), pointer :: first_partref
    type(partref_node_t), pointer :: last_partref
@@ -41,12 +29,35 @@ type, public :: link_node_t
    type(part_nodeptr_t), dimension(:), allocatable :: itemdir2
 end type
 
+! LCRS chain node
+type, public :: chain_node_t
+   integer :: tot_items1
+   integer :: tot_items2
+   integer :: num_links
+   integer :: num_children
+   integer :: global_index
+   integer, pointer :: total_chains => null()
+   integer, pointer :: total_links => null()
+   integer, pointer :: total_partrefs => null()
+   type(chain_node_t), pointer :: parent_chain
+   type(chain_node_t), pointer :: first_child_chain
+   type(chain_node_t), pointer :: last_child_chain
+   type(chain_node_t), pointer :: next_sibling_chain
+   type(link_node_t), pointer :: first_link
+   type(link_node_t), pointer :: last_link
+   type(part_node_t), pointer :: split_part
+end type
+
 ! LCRS part node
 type, public :: part_node_t
+   integer :: depth
+   integer :: global_index
    integer :: num_items1
    integer :: num_items2
    integer :: num_children
-   integer :: depth
+   integer, pointer :: total_parts => null()
+   integer, pointer :: total_items1 => null()
+   integer, pointer :: total_items2 => null()
    type(item_node_t), pointer :: first_item1
    type(item_node_t), pointer :: first_item2
    type(item_node_t), pointer :: last_item1
@@ -64,43 +75,35 @@ type, public :: part_nodeptr_t
 end type
 
 ! Semipart array
-type, public :: semipartarray_t
+type, public :: semipartition_part_t
    integer :: num_items
    integer, dimension(:), allocatable :: items
 end type
 
 ! Semipartition array
-type, public :: semipartitionarray_t
+type, public :: semipartition_t
    integer :: num_parts
-   type(semipartarray_t), dimension(:), allocatable :: parts
+   type(semipartition_part_t), dimension(:), allocatable :: parts
    integer, dimension(:), allocatable :: itemdir
 end type
 
 ! Part array
-type, public :: partarray_t
-   integer :: num_children
+type, public :: partition_part_t
    integer :: num_items1
    integer :: num_items2
-   integer, dimension(:), allocatable :: children
+   integer :: num_children
    integer, dimension(:), allocatable :: items1
    integer, dimension(:), allocatable :: items2
    integer, dimension(:), allocatable :: signature
+   integer, dimension(:), allocatable :: children
 end type
 
 ! Partition array
-type, public :: partitionarray_t
+type, public :: partition_t
    integer :: num_parts
-   type(partarray_t), dimension(:), allocatable :: parts
+   type(partition_part_t), dimension(:), allocatable :: parts
    integer, dimension(:), allocatable :: itemdir1
    integer, dimension(:), allocatable :: itemdir2
-end type
-
-! Partchain array
-type, public :: chainarray_t
-   integer :: num_links
-   integer :: tot_items1
-   integer :: tot_items2
-   type(partitionarray_t), dimension(:), allocatable :: partitions
 end type
 
 interface address
@@ -118,40 +121,37 @@ end interface
 ! Make types and procedures public
 public address
 public isdescendant
-public new_root_branch
-public new_child_branch
-public new_root_link
-public new_generic_link
-public new_root_part
+public new_root_chain
+public new_child_chain
+public new_bare_link
+public new_chain_link
 public new_child_part
 public link_part
 public update_itemdir
 public remove_last_link
-public remove_onlychild_part
 public add_new_item1
 public add_new_item2
 public init_chain_from_link
+public init_chain_from_partition
 public move_first_item1
 public move_first_item2
 public move_part_items
 public delete_chain
 public print_part_tree
-public print_chain
-public print_chainarray
 public print_part_items
 public print_tree_items
 public print_leaf_items
 public print_link_itemdir
 public print_part_signature
 public print_tree_signatures
-public sort_parts_by_size
-public partition_to_partitionarray
-public init_chain_from_partarray
+public print_part_indices
+public print_chain_indices
+public link_to_partition
 public find_child_part
 public first_partition
 public second_partition
 public add_branch_part
-public print_split_tree
+public print_chain_tree
 public delete_part_tree
 public delete_part
 public operator(==)
@@ -225,16 +225,34 @@ logical function isdescendant(part, top_part)
    end if
 end function
 
-function new_root_part(depth) result(new_part)
-   integer, intent(in) :: depth
+function new_root_part() result(new_part)
+   type(part_node_t), pointer :: new_part
+
+   new_part => new_bare_part()
+   new_part%depth = 0
+   
+   ! Allocate counters for root and assign initial values
+   allocate(new_part%total_parts)
+   allocate(new_part%total_items1)
+   allocate(new_part%total_items2)
+   new_part%total_parts = 0  ! Root is not counted
+   new_part%total_items1 = 0  ! No items initially
+   new_part%total_items2 = 0  ! No items initially
+   new_part%global_index = 0 ! Root gets special index 0
+end function
+
+function new_bare_part() result(new_part)
    type(part_node_t), pointer :: new_part
 
    allocate (new_part)
 
-   new_part%num_children = 0
+   new_part%global_index = 0  ! Will be set when added to tree
    new_part%num_items1 = 0
    new_part%num_items2 = 0
-   new_part%depth = depth
+   new_part%num_children = 0
+   new_part%total_parts => null()
+   new_part%total_items1 => null()
+   new_part%total_items2 => null()
    new_part%parent_part => null()
    new_part%first_item1 => null()
    new_part%last_item1 => null()
@@ -254,7 +272,10 @@ subroutine link_part(link, part)
    allocate(newref)
    newref%part => part
    newref%nextref => null()
-   newref%parent_link => link
+   
+   ! Assign global index and increment counter
+   link%total_partrefs = link%total_partrefs + 1
+   newref%global_index = link%total_partrefs
 
    if (.not. associated(link%first_partref)) then
       link%first_partref => newref
@@ -270,11 +291,21 @@ function new_child_part(parent_part) result(new_part)
    type(part_node_t), pointer :: new_part
 
    ! Create new part with correct depth
-   new_part => new_root_part(parent_part%depth + 1)
+   new_part => new_bare_part()
+   new_part%depth = parent_part%depth + 1
 
    ! Set parent BEFORE setting up relationships
    new_part%parent_part => parent_part
    new_part%next_sibling_part => null()
+
+   ! Point to parent's counters
+   new_part%total_parts => parent_part%total_parts
+   new_part%total_items1 => parent_part%total_items1
+   new_part%total_items2 => parent_part%total_items2
+   
+   ! Assign global index and increment counter
+   new_part%total_parts = new_part%total_parts + 1
+   new_part%global_index = new_part%total_parts
 
    ! Set up parent-child relationships (NO link association)
    if (.not. associated(parent_part%first_child_part)) then
@@ -295,6 +326,10 @@ subroutine add_new_item1(part, value)
    allocate(new_item)
    new_item%value = value
    new_item%next_item => null()
+   
+   ! Assign global index and increment counter
+   part%total_items1 = part%total_items1 + 1
+   new_item%global_index = part%total_items1
 
    if (.not. associated(part%first_item1)) then
       part%first_item1 => new_item
@@ -314,6 +349,10 @@ subroutine add_new_item2(part, value)
    allocate(new_item)
    new_item%value = value
    new_item%next_item => null()
+   
+   ! Assign global index and increment counter
+   part%total_items2 = part%total_items2 + 1
+   new_item%global_index = part%total_items2
 
    if (.not. associated(part%first_item2)) then
       part%first_item2 => new_item
@@ -394,7 +433,7 @@ subroutine move_part_items(src, dest)
 end subroutine
 
 subroutine delete_chain(chain_root)
-   type(split_node_t), pointer, intent(inout) :: chain_root
+   type(chain_node_t), pointer, intent(inout) :: chain_root
    type(link_node_t), pointer :: link, next_link
 
    if ((.not. associated(chain_root))) error stop
@@ -403,7 +442,7 @@ subroutine delete_chain(chain_root)
    link => chain_root%first_link
    do while (associated(link))
       next_link => link%next_link
-      call delete_partition(link)
+      call delete_link(link)
       link => next_link
    end do
 
@@ -412,14 +451,14 @@ subroutine delete_chain(chain_root)
    chain_root => null()
 end subroutine
 
-subroutine delete_partition(parent_link)
-   type(link_node_t), pointer, intent(inout) :: parent_link
+subroutine delete_link(link)
+   type(link_node_t), pointer, intent(inout) :: link
    type(partref_node_t), pointer :: partref, nextref
 
-   if ((.not. associated(parent_link))) error stop
+   if ((.not. associated(link))) error stop
 
    ! Delete all part references WITHOUT deleting the parts themselves
-   partref => parent_link%first_partref
+   partref => link%first_partref
    do while (associated(partref))
       nextref => partref%nextref
 
@@ -429,12 +468,12 @@ subroutine delete_partition(parent_link)
    end do
 
    ! Deallocate directories (always allocated)
-   deallocate(parent_link%itemdir1)
-   deallocate(parent_link%itemdir2)
+   deallocate(link%itemdir1)
+   deallocate(link%itemdir2)
 
    ! Deallocate partition root
-   deallocate(parent_link)
-   parent_link => null()
+   deallocate(link)
+   link => null()
 end subroutine
 
 subroutine delete_part_tree(root_part)
@@ -445,6 +484,11 @@ subroutine delete_part_tree(root_part)
 
    ! Recursively delete all children first
    call delete_part_children(root_part)
+
+   ! Deallocate counters
+   deallocate(root_part%total_parts)
+   deallocate(root_part%total_items1)
+   deallocate(root_part%total_items2)
 
    ! Then delete the root part itself
    call delete_part(root_part)
@@ -504,19 +548,19 @@ subroutine deallocate_items(first_item)
    first_item => null()
 end subroutine
 
-subroutine partition_to_partitionarray(parent_link, partition)
-   type(link_node_t), target, intent(in) :: parent_link
-   type(partitionarray_t), intent(out) :: partition
+subroutine link_to_partition(link, partition)
+   type(link_node_t), target, intent(in) :: link
+   type(partition_t), intent(out) :: partition
    type(partref_node_t), pointer :: partref
    type(item_node_t), pointer :: item
    integer :: i, j
 
-   partition%num_parts = parent_link%num_parts
+   partition%num_parts = link%num_parts
    allocate(partition%parts(partition%num_parts))
-   allocate(partition%itemdir1(size(parent_link%itemdir1)))
-   allocate(partition%itemdir2(size(parent_link%itemdir2)))
+   allocate(partition%itemdir1(size(link%itemdir1)))
+   allocate(partition%itemdir2(size(link%itemdir2)))
 
-   partref => parent_link%first_partref
+   partref => link%first_partref
    i = 1
    do while (associated(partref))
       if (.not. associated(partref%part)) error stop
@@ -583,94 +627,123 @@ subroutine print_link_itemdir(link)
    end do
 end subroutine
 
-function new_root_branch(tot_items1, tot_items2) result(new_branch)
+function new_bare_chain(tot_items1, tot_items2) result(new_chain)
    integer, intent(in) :: tot_items1, tot_items2
-   type(split_node_t), pointer :: new_branch
+   type(chain_node_t), pointer :: new_chain
 
-   allocate(new_branch)
-   new_branch%num_links = 0
-   new_branch%num_children = 0
-   new_branch%tot_items1 = tot_items1
-   new_branch%tot_items2 = tot_items2
-   new_branch%split_part => null()
-   new_branch%parent_branch => null()
-   new_branch%first_child_branch => null()
-   new_branch%last_child_branch => null()
-   new_branch%next_sibling_branch => null()
-   new_branch%first_link => null()
-   new_branch%last_link => null()
+   allocate(new_chain)
+   new_chain%num_links = 0
+   new_chain%num_children = 0
+   new_chain%global_index = 0  ! Will be set when added to tree
+   new_chain%tot_items1 = tot_items1
+   new_chain%tot_items2 = tot_items2
+   new_chain%total_chains => null()
+   new_chain%total_links => null()
+   new_chain%total_partrefs => null()
+   new_chain%first_child_chain => null()
+   new_chain%last_child_chain => null()
+   new_chain%next_sibling_chain => null()
+   new_chain%first_link => null()
+   new_chain%last_link => null()
 end function
 
-function new_root_link() result(new_link)
+function new_root_chain(tot_items1, tot_items2) result(new_chain)
+   integer, intent(in) :: tot_items1, tot_items2
+   type(chain_node_t), pointer :: new_chain
+
+   new_chain => new_bare_chain(tot_items1, tot_items2)
+   new_chain%parent_chain => null()
+   new_chain%split_part => null()
+   new_chain%global_index = 0  ! Root gets special index 0
+   
+   ! Allocate counters for root and assign initial values
+   allocate(new_chain%total_chains)
+   allocate(new_chain%total_links)
+   allocate(new_chain%total_partrefs)
+   new_chain%total_chains = 0   ! Root is not counted
+   new_chain%total_links = 0    ! No links initially
+   new_chain%total_partrefs = 0 ! No partrefs initially
+end function
+
+function new_bare_link() result(new_link)
    type(link_node_t), pointer :: new_link
 
    allocate(new_link)
    new_link%num_parts = 0
+   new_link%global_index = 0  ! Will be set when added to chain
+   new_link%total_partrefs => null()
    new_link%first_partref => null()
    new_link%last_partref => null()
    new_link%next_link => null()
 end function
 
-function new_generic_link(branch) result(new_link)
-   type(split_node_t), target, intent(inout) :: branch
+function new_chain_link(chain) result(new_link)
+   type(chain_node_t), target, intent(inout) :: chain
    type(link_node_t), pointer :: new_link
    integer :: i
 
    ! Use the initialization function
-   new_link => new_root_link()
+   new_link => new_bare_link()
+   
+   ! Point to chain's partref counter
+   new_link%total_partrefs => chain%total_partrefs
+   
+   ! Assign global index and increment counter
+   chain%total_links = chain%total_links + 1
+   new_link%global_index = chain%total_links
 
    ! Allocate item directories
-   allocate(new_link%itemdir1(branch%tot_items1))
-   allocate(new_link%itemdir2(branch%tot_items2))
+   allocate(new_link%itemdir1(chain%tot_items1))
+   allocate(new_link%itemdir2(chain%tot_items2))
 
    ! Initialize all pointers to null
-   do i = 1, branch%tot_items1
+   do i = 1, chain%tot_items1
       new_link%itemdir1(i)%ptr => null()
    end do
-   do i = 1, branch%tot_items2
+   do i = 1, chain%tot_items2
       new_link%itemdir2(i)%ptr => null()
    end do
 
-   ! Add link to branch
-   if (.not. associated(branch%first_link)) then
-      branch%first_link => new_link
+   ! Add link to chain
+   if (.not. associated(chain%first_link)) then
+      chain%first_link => new_link
    else
-      branch%last_link%next_link => new_link
+      chain%last_link%next_link => new_link
    end if
-   branch%last_link => new_link
-   branch%num_links = branch%num_links + 1
+   chain%last_link => new_link
+   chain%num_links = chain%num_links + 1
 end function
 
-subroutine remove_last_link(branch)
-   type(split_node_t), pointer, intent(inout) :: branch
+subroutine remove_last_link(chain)
+   type(chain_node_t), pointer, intent(inout) :: chain
    type(link_node_t), pointer :: link_to_remove, prev_link
 
-   if (.not. associated(branch%last_link)) then
-      error stop "Cannot remove last link: no links in branch"
+   if (.not. associated(chain%last_link)) then
+      error stop "Cannot remove last link: no links in chain"
    end if
 
-   link_to_remove => branch%last_link
+   link_to_remove => chain%last_link
 
    ! If this is the only link
-   if (associated(branch%first_link, branch%last_link)) then
-      branch%first_link => null()
-      branch%last_link => null()
+   if (associated(chain%first_link, chain%last_link)) then
+      chain%first_link => null()
+      chain%last_link => null()
    else
       ! Find the previous link
-      prev_link => branch%first_link
+      prev_link => chain%first_link
       do while (.not. associated(prev_link%next_link, link_to_remove))
          prev_link => prev_link%next_link
       end do
 
       ! Update pointers
       prev_link%next_link => null()
-      branch%last_link => prev_link
+      chain%last_link => prev_link
    end if
 
-   branch%num_links = branch%num_links - 1
+   chain%num_links = chain%num_links - 1
 
    ! Delete the removed link
-   call delete_partition(link_to_remove)
+   call delete_link(link_to_remove)
 end subroutine
 
 function find_child_part(part, signature) result(child_part)
@@ -766,219 +839,9 @@ recursive subroutine print_part_recursive(part, depth, is_last_child)
    end do
 end subroutine
 
-subroutine print_chain(chain_root)
-   type(split_node_t), pointer, intent(in) :: chain_root
-   type(link_node_t), pointer :: link
-   integer :: link_idx
-
-   if (.not. associated(chain_root)) error stop
-
-   write(stderr,*)
-   write(stderr,'(A)') repeat("=", 17)
-   write(stderr,'(A)') " Partition chain"
-   write(stderr,'(A)') repeat("=", 17)
-
-   ! Print all partitions in this chain
-   link => chain_root%first_link
-   link_idx = 1
-   do while (associated(link))
-      call print_partition(link, link_idx)
-      link => link%next_link
-      link_idx = link_idx + 1
-   end do
-
-   write(stderr,*)  ! Final newline
-end subroutine
-
-subroutine print_partition(parent_link, link_idx)
-   type(link_node_t), pointer, intent(in) :: parent_link
-   integer, intent(in) :: link_idx
-
-   if (.not. associated(parent_link)) error stop
-
-   write(stderr,*)
-   write(stderr,'(A,I0,A)') "( Link ", link_idx, " )"
-
-   ! Print part items
-   call print_partition_items(parent_link)
-
-   ! Print part signatures
-   call print_partition_signatures(parent_link)
-
-   ! Print part children
-   call print_partition_children(parent_link)
-end subroutine
-
-subroutine print_partition_items(parent_link)
-   type(link_node_t), pointer, intent(in) :: parent_link
-   type(partref_node_t), pointer :: partref
-
-   if (.not. associated(parent_link)) error stop
-
-   write(stderr, *)
-   write(stderr,'(A)') "Items"
-   write(stderr,'(A)') repeat("-", 6)
-
-   partref => parent_link%first_partref
-   do while (associated(partref))
-      write(stderr, '(A)', advance='no') address(partref%part) // ':'
-      call print_part_items(partref%part)
-      partref => partref%nextref
-   end do
-end subroutine
-
-subroutine print_partition_children(parent_link)
-   type(link_node_t), pointer, intent(in) :: parent_link
-   type(partref_node_t), pointer :: partref
-   type(part_node_t), pointer :: child_part
-
-   if (.not. associated(parent_link)) error stop
-
-   write(stderr,*)
-   write(stderr,'(A)') "Children"
-   write(stderr,'(A)') repeat("-", 9)
-
-   partref => parent_link%first_partref
-   do while (associated(partref))
-      ! Print part address
-      write(stderr,'(A)',advance='no') address(partref%part) // ":"
-
-      ! Print part children
-      child_part => partref%part%first_child_part
-      do while (associated(child_part))
-         ! Print which part in next partition this child_part points to
-         write(stderr,'(1X,A)',advance='no') address(child_part)
-         child_part => child_part%next_sibling_part
-      end do
-      write(stderr,*)
-
-      partref => partref%nextref
-   end do
-end subroutine
-
-subroutine print_partition_signatures(parent_link)
-   type(link_node_t), pointer, intent(in) :: parent_link
-   type(partref_node_t), pointer :: partref
-
-   if (.not. associated(parent_link)) error stop
-
-   write(stderr,*)
-   write(stderr,'(A)') "Signatures"
-   write(stderr,'(A)') repeat("-", 11)
-
-   partref => parent_link%first_partref
-   do while (associated(partref))
-      ! Print part address
-      write(stderr,'(A)',advance='no') address(partref%part) // ":"
-
-      ! Print part signature using the new procedure
-      call print_part_signature(partref%part%signature)
-
-      partref => partref%nextref
-   end do
-end subroutine
-
-subroutine print_chainarray(chainarray)
-   type(chainarray_t), intent(in) :: chainarray
-   integer :: link_idx
-
-   write(stderr,*)
-   write(stderr,'(A)') repeat("=", 17)
-   write(stderr,'(A)') " Partition chain"
-   write(stderr,'(A)') repeat("=", 17)
-
-   ! Print each link
-   do link_idx = 1, chainarray%num_links
-      call print_partitionarray(chainarray, link_idx)
-   end do
-
-   write(stderr,*)  ! Final newline
-end subroutine
-
-subroutine print_partitionarray(chainarray, link_idx)
-   type(chainarray_t), intent(in) :: chainarray
-   integer, intent(in) :: link_idx
-
-   write(stderr,*)
-   write(stderr,'(A,I0,A)') "( Link ", link_idx, " )"
-
-   ! Print part items
-   call print_partitionarray_items(chainarray, link_idx)
-
-   ! Print part signatures
-   call print_partitionarray_signatures(chainarray, link_idx)
-
-   ! Print part children
-   call print_partitionarray_children(chainarray, link_idx)
-end subroutine
-
-subroutine print_partitionarray_items(chainarray, link_idx)
-   type(chainarray_t), intent(in) :: chainarray
-   integer, intent(in) :: link_idx
-   integer :: i, j
-
-   write(stderr, *)
-   write(stderr,'(A)') "Items"
-   write(stderr,'(A)') repeat("-", 6)
-
-   do i = 1, chainarray%partitions(link_idx)%num_parts
-      write(stderr, '(I3,A)', advance='no') i, ':'
-
-      do j = 1, chainarray%partitions(link_idx)%parts(i)%num_items1
-         write(stderr,'(1X,I0)',advance='no') chainarray%partitions(link_idx)%parts(i)%items1(j)
-      end do
-
-      write(stderr,'(A)',advance='no') ' /'
-
-      do j = 1, chainarray%partitions(link_idx)%parts(i)%num_items2
-         write(stderr,'(1X,I0)',advance='no') chainarray%partitions(link_idx)%parts(i)%items2(j)
-      end do
-
-      write(stderr,*)
-   end do
-end subroutine
-
-subroutine print_partitionarray_children(chainarray, link_idx)
-   type(chainarray_t), intent(in) :: chainarray
-   integer, intent(in) :: link_idx
-   integer :: i, j
-
-   write(stderr,*)
-   write(stderr,'(A)') "Children"
-   write(stderr,'(A)') repeat("-", 9)
-
-   do i = 1, chainarray%partitions(link_idx)%num_parts
-      write(stderr,'(I3,A)',advance='no') i, ":"
-      do j = 1, chainarray%partitions(link_idx)%parts(i)%num_children
-         write(stderr,'(1X,I3)',advance='no') &
-            chainarray%partitions(link_idx)%parts(i)%children(j)
-      end do
-      write(stderr,*)
-   end do
-end subroutine
-
-subroutine print_partitionarray_signatures(chainarray, link_idx)
-   type(chainarray_t), intent(in) :: chainarray
-   integer, intent(in) :: link_idx
-   integer :: i, j
-
-   write(stderr,*)
-   write(stderr,'(A)') "Signatures"
-   write(stderr,'(A)') repeat("-", 10)
-
-   do i = 1, chainarray%partitions(link_idx)%num_parts
-      write(stderr,'(I3,A)',advance='no') i, ":"
-      do j = 1, size(chainarray%partitions(link_idx)%parts(i)%signature)
-         write(stderr,'(1X,I3)',advance='no') &
-            chainarray%partitions(link_idx)%parts(i)%signature(j)
-      end do
-      write(stderr,*)
-   end do
-end subroutine
-
 subroutine init_chain_from_link(input_link, chain_root, root_part)
    type(link_node_t), intent(in) :: input_link
-   type(split_node_t), pointer, intent(out) :: chain_root
+   type(chain_node_t), pointer, intent(out) :: chain_root
    type(part_node_t), pointer, intent(out) :: root_part
    type(link_node_t), pointer :: first_link
    type(part_node_t), pointer :: new_part
@@ -986,13 +849,13 @@ subroutine init_chain_from_link(input_link, chain_root, root_part)
    type(item_node_t), pointer :: item
 
    ! Create root part (decoupled from chain)
-   root_part => new_root_part(0)
+   root_part => new_root_part()
 
    ! Create root chain using itemdir sizes from input link
-   chain_root => new_root_branch(size(input_link%itemdir1), size(input_link%itemdir2))
+   chain_root => new_root_chain(size(input_link%itemdir1), size(input_link%itemdir2))
 
    ! Create first link
-   first_link => new_generic_link(chain_root)
+   first_link => new_chain_link(chain_root)
 
    ! Process all parts referenced in the input link
    partref => input_link%first_partref
@@ -1020,22 +883,22 @@ subroutine init_chain_from_link(input_link, chain_root, root_part)
    end do
 end subroutine
 
-subroutine init_chain_from_partarray(partition, chain_root, root_part)
-   type(partitionarray_t), intent(in) :: partition
-   type(split_node_t), pointer, intent(out) :: chain_root
+subroutine init_chain_from_partition(partition, chain_root, root_part)
+   type(partition_t), intent(in) :: partition
+   type(chain_node_t), pointer, intent(out) :: chain_root
    type(part_node_t), pointer, intent(out) :: root_part
    type(link_node_t), pointer :: first_link
    type(part_node_t), pointer :: new_part
    integer :: i, j
 
    ! Create root part (decoupled from chain)
-   root_part => new_root_part(0)
+   root_part => new_root_part()
 
    ! Create root chain
-   chain_root => new_root_branch(size(partition%itemdir1), size(partition%itemdir2))
+   chain_root => new_root_chain(size(partition%itemdir1), size(partition%itemdir2))
 
    ! Create first link
-   first_link => new_generic_link(chain_root)
+   first_link => new_chain_link(chain_root)
 
    ! Create parts as children of root_part and add them to the first link
    do i = 1, partition%num_parts
@@ -1057,105 +920,73 @@ subroutine init_chain_from_partarray(partition, chain_root, root_part)
    end do
 end subroutine
 
-function first_partition(bipartition) result(partition)
-   type(partitionarray_t), intent(in) :: bipartition
-   type(semipartitionarray_t) :: partition
+function first_partition(partition) result(semipartition)
+   type(partition_t), intent(in) :: partition
+   type(semipartition_t) :: semipartition
    integer :: i
 
-   partition%num_parts = bipartition%num_parts
-   allocate(partition%parts(partition%num_parts))
-   allocate(partition%itemdir(size(bipartition%itemdir1)))
-   partition%itemdir = bipartition%itemdir1
+   semipartition%num_parts = partition%num_parts
+   allocate(semipartition%parts(semipartition%num_parts))
+   allocate(semipartition%itemdir(size(partition%itemdir1)))
+   semipartition%itemdir = partition%itemdir1
 
-   do i = 1, partition%num_parts
-      partition%parts(i)%num_items = bipartition%parts(i)%num_items1
-      allocate(partition%parts(i)%items(partition%parts(i)%num_items))
-      partition%parts(i)%items = bipartition%parts(i)%items1
+   do i = 1, semipartition%num_parts
+      semipartition%parts(i)%num_items = partition%parts(i)%num_items1
+      allocate(semipartition%parts(i)%items(semipartition%parts(i)%num_items))
+      semipartition%parts(i)%items = partition%parts(i)%items1
    end do
 end function
 
-function second_partition(bipartition) result(partition)
-   type(partitionarray_t), intent(in) :: bipartition
-   type(semipartitionarray_t) :: partition
+function second_partition(partition) result(semipartition)
+   type(partition_t), intent(in) :: partition
+   type(semipartition_t) :: semipartition
    integer :: i
 
-   partition%num_parts = bipartition%num_parts
-   allocate(partition%parts(partition%num_parts))
-   allocate(partition%itemdir(size(bipartition%itemdir2)))
-   partition%itemdir = bipartition%itemdir2
+   semipartition%num_parts = partition%num_parts
+   allocate(semipartition%parts(semipartition%num_parts))
+   allocate(semipartition%itemdir(size(partition%itemdir2)))
+   semipartition%itemdir = partition%itemdir2
 
-   do i = 1, partition%num_parts
-      partition%parts(i)%num_items = bipartition%parts(i)%num_items2
-      allocate(partition%parts(i)%items(partition%parts(i)%num_items))
-      partition%parts(i)%items = bipartition%parts(i)%items2
+   do i = 1, semipartition%num_parts
+      semipartition%parts(i)%num_items = partition%parts(i)%num_items2
+      allocate(semipartition%parts(i)%items(semipartition%parts(i)%num_items))
+      semipartition%parts(i)%items = partition%parts(i)%items2
    end do
 end function
 
-subroutine sort_parts_by_size(parent_link)
-   type(link_node_t), pointer, intent(inout) :: parent_link
-   type(partref_node_t), pointer :: partref, nextref, prevref
-   logical :: swapped
-
-   ! Bubble sort implementation for part reference linked list
-   do
-      swapped = .false.
-      partref => parent_link%first_partref
-      prevref => null()
-      do while (associated(partref) .and. associated(partref%nextref))
-         nextref => partref%nextref
-         ! Check if we need to swap (current has more items than next)
-         if (partref%part%num_items1 > nextref%part%num_items1) then
-            swapped = .true.
-            ! Perform the swap
-            partref%nextref => nextref%nextref
-            nextref%nextref => partref
-            if (associated(prevref)) then
-               prevref%nextref => nextref
-            else
-               ! Update first_partref if we're swapping the first element
-               parent_link%first_partref => nextref
-            end if
-            ! Update last_partref if necessary
-            if (.not. associated(partref%nextref)) then
-               parent_link%last_partref => partref
-            end if
-            ! Update prevref for next iteration
-            prevref => nextref
-         else
-            ! No swap needed, just advance
-            prevref => partref
-            partref => nextref
-         end if
-      end do
-      ! If no swaps occurred, the list is sorted
-      if (.not. swapped) exit
-   end do
-end subroutine
-
-function new_child_branch(branch, split_part) result(new_branch)
-   type(split_node_t), pointer, intent(inout) :: branch
+function new_child_chain(chain, split_part) result(new_chain)
+   type(chain_node_t), pointer, intent(inout) :: chain
    type(part_node_t), pointer, intent(in) :: split_part
-   type(split_node_t), pointer :: new_branch
+   type(chain_node_t), pointer :: new_chain
 
-   ! Create new child branch
-   new_branch => new_root_branch(branch%tot_items1, branch%tot_items2)
-   new_branch%split_part => split_part
+   ! Create new child chain
+   new_chain => new_bare_chain(chain%tot_items1, chain%tot_items2)
+   new_chain%split_part => split_part
 
    ! Set up parent-child relationship
-   new_branch%parent_branch => branch
+   new_chain%parent_chain => chain
+   
+   ! Point to parent's counters
+   new_chain%total_chains => chain%total_chains
+   new_chain%total_links => chain%total_links
+   new_chain%total_partrefs => chain%total_partrefs
+   
+   ! Assign global index and increment counter
+   new_chain%total_chains = new_chain%total_chains + 1
+   new_chain%global_index = new_chain%total_chains
 
-   ! Add as child to parent (optimized with last_child_branch pointer)
-   if (.not. associated(branch%first_child_branch)) then
+   ! Add as child to parent (optimized with last_child_chain pointer)
+   if (.not. associated(chain%first_child_chain)) then
       ! This is the first child
-      branch%first_child_branch => new_branch
-      branch%last_child_branch => new_branch
+      chain%first_child_chain => new_chain
+      chain%last_child_chain => new_chain
    else
       ! Add as next sibling to the current last child
-      branch%last_child_branch%next_sibling_branch => new_branch
-      branch%last_child_branch => new_branch
+      chain%last_child_chain%next_sibling_chain => new_chain
+      chain%last_child_chain => new_chain
    end if
 
-   branch%num_children = branch%num_children + 1
+   chain%num_children = chain%num_children + 1
 end function
 
 subroutine add_branch_part(link, part)
@@ -1171,7 +1002,6 @@ subroutine add_branch_part(link, part)
    allocate(newref)
    newref%part => part
    newref%nextref => null()
-   newref%parent_link => link
 
    ! If link is empty, add as first element
    if (.not. associated(link%first_partref)) then
@@ -1237,27 +1067,11 @@ subroutine update_itemdir(link, part)
    end do
 end subroutine
 
-subroutine remove_onlychild_part(parent_part)
-! Remove the only child part (since we know leaf parts start with 0 children)
-   type(part_node_t), pointer, intent(inout) :: parent_part
-
-   ! Assert only child
-   if (parent_part%num_children /= 1) error stop
-
-   ! Delete the child part (no itemdir cleanup needed)
-   call delete_part(parent_part%first_child_part)
-
-   ! Reset parent's child pointers (removing the only child)
-   parent_part%first_child_part => null()
-   parent_part%last_child_part => null()
-   parent_part%num_children = 0
-end subroutine
-
-subroutine print_split_tree(root_branch)
-   type(split_node_t), pointer, intent(in) :: root_branch
+subroutine print_chain_tree(root_chain)
+   type(chain_node_t), pointer, intent(in) :: root_chain
    logical, dimension(:), allocatable :: is_last_child
 
-   if (.not. associated(root_branch)) error stop
+   if (.not. associated(root_chain)) error stop
 
    write(stderr, *)
    write(stderr, '(A)') repeat("=", 25)
@@ -1271,27 +1085,27 @@ subroutine print_split_tree(root_branch)
 
    ! Print children recursively
    write(stderr, '(A)') 'ROOT'
-   call print_split_recursive(root_branch, 0, is_last_child)
+   call print_chain_recursive(root_chain, 0, is_last_child)
 
    deallocate(is_last_child)
    write(stderr, *)
 end subroutine
 
-recursive subroutine print_split_recursive(branch, depth, is_last_child)
-   type(split_node_t), pointer, intent(in) :: branch
+recursive subroutine print_chain_recursive(chain, depth, is_last_child)
+   type(chain_node_t), pointer, intent(in) :: chain
    integer, intent(in) :: depth
    logical, dimension(:), intent(inout) :: is_last_child
-   type(split_node_t), pointer :: child_branch, next_child
+   type(chain_node_t), pointer :: child_chain, next_child
    integer :: i, pos
    character(len=200) :: prefix
 
-   if (.not. associated(branch)) return
+   if (.not. associated(chain)) return
 
    ! Process all children
-   child_branch => branch%first_child_branch
-   do while (associated(child_branch))
+   child_chain => chain%first_child_chain
+   do while (associated(child_chain))
       ! Check if this is the last child
-      next_child => child_branch%next_sibling_branch
+      next_child => child_chain%next_sibling_chain
       is_last_child(depth + 1) = .not. associated(next_child)
 
       ! Build prefix for this level
@@ -1315,13 +1129,13 @@ recursive subroutine print_split_recursive(branch, depth, is_last_child)
       pos = pos + 3
 
       ! Print the child address with item counts
-      write(stderr, '(A,A,1X,A,I0,A,I0,A)') prefix(1:pos-1), address(child_branch%split_part), &
-         '(', child_branch%split_part%num_items1, '/', child_branch%split_part%num_items2, ')'
+      write(stderr, '(A,A,1X,A,I0,A,I0,A)') prefix(1:pos-1), address(child_chain%split_part), &
+         '(', child_chain%split_part%num_items1, '/', child_chain%split_part%num_items2, ')'
 
       ! Recursively print this child's children
-      call print_split_recursive(child_branch, depth + 1, is_last_child)
+      call print_chain_recursive(child_chain, depth + 1, is_last_child)
 
-      child_branch => next_child
+      child_chain => next_child
    end do
 end subroutine
 
@@ -1456,6 +1270,127 @@ recursive subroutine print_leaf_items_recursive(part)
       call print_leaf_items_recursive(child_part)
 
       child_part => child_part%next_sibling_part
+   end do
+end subroutine
+
+! New procedure to print global indices
+subroutine print_part_indices(root_part)
+   type(part_node_t), pointer, intent(in) :: root_part
+
+   if (.not. associated(root_part)) then
+      write(stderr, '(A)') "Part tree is empty"
+      return
+   end if
+
+   write(stderr, *)
+   write(stderr, '(A)') repeat("=", 35)
+   write(stderr, '(A)') "        Global Indices"
+   write(stderr, '(A)') repeat("=", 35)
+   write(stderr, *)
+   write(stderr, '(A,I0)') "Total parts created: ", root_part%total_parts
+   write(stderr, '(A,I0)') "Total items1 created: ", root_part%total_items1
+   write(stderr, '(A,I0)') "Total items2 created: ", root_part%total_items2
+   write(stderr, *)
+
+   ! Print children recursively
+   call print_part_indices_recursive(root_part)
+
+   write(stderr, *)
+end subroutine
+
+! Helper recursive procedure for print_part_indices
+recursive subroutine print_part_indices_recursive(part)
+   type(part_node_t), pointer, intent(in) :: part
+   type(part_node_t), pointer :: child_part
+   type(item_node_t), pointer :: item
+
+   if (.not. associated(part)) return
+
+   ! Process all children
+   child_part => part%first_child_part
+   do while (associated(child_part))
+      ! Print the child part index
+      write(stderr, '(A,I0,A,A,A)') "Part ", child_part%global_index, " (address: ", address(child_part), ")"
+      
+      ! Print items in this part
+      item => child_part%first_item1
+      do while (associated(item))
+         write(stderr, '(A,I0,A,I0,A)') "  Item1 ", item%global_index, " (value: ", item%value, ")"
+         item => item%next_item
+      end do
+      
+      item => child_part%first_item2
+      do while (associated(item))
+         write(stderr, '(A,I0,A,I0,A)') "  Item2 ", item%global_index, " (value: ", item%value, ")"
+         item => item%next_item
+      end do
+
+      ! Recursively print this child's children
+      call print_part_indices_recursive(child_part)
+
+      child_part => child_part%next_sibling_part
+   end do
+end subroutine
+
+! New procedure to print global indices for chain tree
+subroutine print_chain_indices(root_chain)
+   type(chain_node_t), pointer, intent(in) :: root_chain
+
+   if (.not. associated(root_chain)) then
+      write(stderr, '(A)') "Chain tree is empty"
+      return
+   end if
+
+   write(stderr, *)
+   write(stderr, '(A)') repeat("=", 35)
+   write(stderr, '(A)') "     Chain Global Indices"
+   write(stderr, '(A)') repeat("=", 35)
+   write(stderr, *)
+   write(stderr, '(A,I0)') "Total chains created: ", root_chain%total_chains
+   write(stderr, '(A,I0)') "Total links created: ", root_chain%total_links
+   write(stderr, '(A,I0)') "Total partrefs created: ", root_chain%total_partrefs
+   write(stderr, *)
+
+   ! Print children recursively
+   call print_chain_indices_recursive(root_chain)
+
+   write(stderr, *)
+end subroutine
+
+! Helper recursive procedure for print_chain_indices
+recursive subroutine print_chain_indices_recursive(chain)
+   type(chain_node_t), pointer, intent(in) :: chain
+   type(chain_node_t), pointer :: child_chain
+   type(link_node_t), pointer :: link
+   type(partref_node_t), pointer :: partref
+
+   if (.not. associated(chain)) return
+
+   ! Print links in this chain
+   link => chain%first_link
+   do while (associated(link))
+      write(stderr, '(A,I0,A,I0,A)') "  Link ", link%global_index, " (", link%num_parts, " parts)"
+      
+      ! Print partrefs in this link
+      partref => link%first_partref
+      do while (associated(partref))
+         write(stderr, '(A,I0,A,A,A)') "    Partref ", partref%global_index, " (part: ", address(partref%part), ")"
+         partref => partref%nextref
+      end do
+      
+      link => link%next_link
+   end do
+
+   ! Process all child chains
+   child_chain => chain%first_child_chain
+   do while (associated(child_chain))
+      ! Print the child chain index
+      write(stderr, '(A,I0,A,A,A)') "Chain ", child_chain%global_index, " (split part: ", address(child_chain%split_part), ")"
+
+      ! Recursively print this child's content and children
+      call print_chain_indices_recursive(child_chain)
+
+      child_chain => child_chain%next_sibling_chain
    end do
 end subroutine
 

--- a/molalignlib/mna_compute.f90
+++ b/molalignlib/mna_compute.f90
@@ -52,7 +52,7 @@ end subroutine
 subroutine compute_nextlevel_mnas(mol1, mol2, mnachain, num_splits)
 ! Compute next level MNA types - always keeps all children (original behavior)
    type(mol_type), intent(in) :: mol1, mol2
-   type(split_node_t), pointer, intent(inout) :: mnachain
+   type(chain_node_t), pointer, intent(inout) :: mnachain
    integer, intent(out) :: num_splits
    ! Local variables
    type(link_node_t), pointer :: link, new_link
@@ -62,7 +62,7 @@ subroutine compute_nextlevel_mnas(mol1, mol2, mnachain, num_splits)
 
    ! Save the last link before creating a new one
    link => mnachain%last_link
-   new_link => new_generic_link(mnachain)
+   new_link => new_chain_link(mnachain)
 
    ! Process all parts in the current partition
    partref => link%first_partref
@@ -80,7 +80,7 @@ end subroutine
 subroutine compute_consistent_mnas(mol1, mol2, mnachain)
 ! Iteratively compute MNA types until convergence
    type(mol_type), intent(in) :: mol1, mol2
-   type(split_node_t), pointer, intent(inout) :: mnachain
+   type(chain_node_t), pointer, intent(inout) :: mnachain
    ! Local variables
    integer :: num_splits
 

--- a/molalignlib/mna_precompute.f90
+++ b/molalignlib/mna_precompute.f90
@@ -2,206 +2,209 @@ module mna_precompute
 use parameters
 use molecule
 use lcrs_tree
+use mna_compute
 implicit none
 
 contains
 
-subroutine split_part_mna_nolink(atoms1, atoms2, itemdir1, itemdir2, part)
-! Create children for different signatures - caller decides what to do with them
-! Note: part is always a leaf part with no existing children
+function would_part_split(atoms1, atoms2, itemdir1, itemdir2, part) result(would_split)
+! Check if a part would split by comparing signatures
    type(atom_type), dimension(:), intent(in) :: atoms1, atoms2
    type(part_nodeptr_t), dimension(:), intent(in) :: itemdir1, itemdir2
    type(part_node_t), pointer, intent(inout) :: part
    ! Local variables
-   type(item_node_t), pointer :: item
-   type(part_nodeptr_t), dimension(:), allocatable :: signature
-   type(part_node_t), pointer :: child_part
+   logical :: would_split
+   type(item_node_t), pointer :: item1, item2
+   type(part_nodeptr_t), dimension(:), allocatable :: signature, first_signature
 
-   ! Process first molecule items - create children for each unique signature
-   item => part%first_item1
-   do while (associated(item))
-      signature = itemdir1(atoms1(item%value)%adjlist)
-      child_part => find_child_part(part, signature)
-      if (.not. associated(child_part)) then
-         child_part => new_child_part(part)
-         child_part%signature = signature
+   would_split = .false.
+   item1 => part%first_item1
+   item2 => part%first_item2
+
+   ! Set first signature from first available item
+   if (associated(item1)) then
+      first_signature = itemdir1(atoms1(item1%value)%adjlist)
+      item1 => item1%next_item
+   else if (associated(item2)) then
+      first_signature = itemdir2(atoms2(item2%value)%adjlist)
+      item2 => item2%next_item
+   else
+      return  ! No items to process
+   end if
+
+   ! Check remaining items in first molecule
+   do while (associated(item1))
+      signature = itemdir1(atoms1(item1%value)%adjlist)
+      if (.not. (signature .equiv. first_signature)) then
+         would_split = .true.
+         return
       end if
-      call add_new_item1(child_part, item%value)
-      item => item%next_item
+      item1 => item1%next_item
    end do
 
-   ! Process second molecule items - create children for each unique signature
-   item => part%first_item2
-   do while (associated(item))
-      signature = itemdir2(atoms2(item%value)%adjlist)
-      child_part => find_child_part(part, signature)
-      if (.not. associated(child_part)) then
-         child_part => new_child_part(part)
-         child_part%signature = signature
+   ! Check remaining items in second molecule
+   do while (associated(item2))
+      signature = itemdir2(atoms2(item2%value)%adjlist)
+      if (.not. (signature .equiv. first_signature)) then
+         would_split = .true.
+         return
       end if
-      call add_new_item2(child_part, item%value)
-      item => item%next_item
+      item2 => item2%next_item
    end do
-end subroutine
+end function
 
-subroutine precompute_nextlevel_mnas(mol1, mol2, mnachain, mnabranch, branch_parts, num_splits)
+subroutine precompute_nextlevel_mnas(mol1, mol2, mnachain, leafchain, branch_parts, num_splits)
 ! Compute next level MNA types - only keeps children if real split occurred
    type(mol_type), intent(in) :: mol1, mol2
-   type(split_node_t), pointer, intent(inout) :: mnachain
-   type(split_node_t), pointer, intent(inout) :: mnabranch
+   type(chain_node_t), pointer, intent(inout) :: mnachain
+   type(chain_node_t), pointer, intent(inout) :: leafchain
    type(link_node_t), pointer, intent(inout) :: branch_parts
    integer, intent(out) :: num_splits
    ! Local variables
-   type(link_node_t), pointer :: chain_link, new_chain_link
-   type(link_node_t), pointer :: branch_link, new_branch_link
+   type(link_node_t), pointer :: level_link, next_level_link
+   type(link_node_t), pointer :: leafchain_link, next_leafchain_link
    type(partref_node_t), pointer :: partref
    type(part_node_t), pointer :: child_part
 
    num_splits = 0
 
    ! Save the last chain link pointer before creating a new one
-   chain_link => mnachain%last_link
-   new_chain_link => new_generic_link(mnachain)
+   level_link => mnachain%last_link
+   next_level_link => new_chain_link(mnachain)
 
    ! Save the last branch link pointer before creating a new one
-   branch_link => mnabranch%last_link
-   new_branch_link => new_generic_link(mnabranch)
+   leafchain_link => leafchain%last_link
+   next_leafchain_link => new_chain_link(leafchain)
 
    ! Process all parts in the current partition (all are leaf parts)
-   partref => chain_link%first_partref
+   partref => level_link%first_partref
    do while (associated(partref))
-      ! Create children based on signatures
-      call split_part_mna_nolink(mol1%atoms, mol2%atoms, chain_link%itemdir1, chain_link%itemdir2, partref%part)
-
-      ! Check if real split occurred (more than one child)
-      if (partref%part%num_children > 1) then
+      ! Check if real split would occur (more than one child)
+      if (would_part_split(mol1%atoms, mol2%atoms, level_link%itemdir1, level_link%itemdir2, partref%part)) then
+         ! Create children based on signatures
+         call split_part_mna(mol1%atoms, mol2%atoms, level_link%itemdir1, level_link%itemdir2, partref%part, next_level_link)
          ! Link part to branch link
-         call link_part(branch_link, partref%part)
-         ! Link all children to links
+         call link_part(leafchain_link, partref%part)
+         ! Add part children to branch part list
          child_part => partref%part%first_child_part
          do while (associated(child_part))
-            call link_part(new_chain_link, child_part)
-            call update_itemdir(new_chain_link, child_part)
-!            call update_itemdir(new_branch_link, child_part)
             call add_branch_part(branch_parts, child_part)
             child_part => child_part%next_sibling_part
          end do
          num_splits = num_splits + 1
       else
-         ! No real split (num_children == 1) - remove the single child and reuse original part
-         call remove_onlychild_part(partref%part)
-         call link_part(new_chain_link, partref%part)
+         ! Link original part
+         call link_part(next_level_link, partref%part)
       end if
 
       partref => partref%nextref
    end do
 end subroutine
 
-subroutine precompute_consistent_mnas(mol1, mol2, mnachain, mnabranch, branch_parts)
+subroutine precompute_consistent_mnas(mol1, mol2, mnachain, leafchain, branch_parts)
 ! Iteratively compute MNA types until convergence
    type(mol_type), intent(in) :: mol1, mol2
-   type(split_node_t), pointer, intent(inout) :: mnachain
-   type(split_node_t), pointer, intent(inout) :: mnabranch
+   type(chain_node_t), pointer, intent(inout) :: mnachain
+   type(chain_node_t), pointer, intent(inout) :: leafchain
    type(link_node_t), pointer, intent(inout) :: branch_parts
    ! Local variables
    integer :: num_splits
 
    do
       ! Call compute_nextlevel_mnas and get the number of splits
-      call precompute_nextlevel_mnas(mol1, mol2, mnachain, mnabranch, branch_parts, num_splits)
+      call precompute_nextlevel_mnas(mol1, mol2, mnachain, leafchain, branch_parts, num_splits)
 
       ! If no splits occurred, remove redundant links and return
       if (num_splits == 0) then
          call remove_last_link(mnachain)
-         call remove_last_link(mnabranch)
+         call remove_last_link(leafchain)
          return
       end if
    end do
 end subroutine
 
-subroutine split_part_first(part)
+subroutine split_part_first(part, link)
    type(part_node_t), pointer, intent(inout) :: part
+   type(link_node_t), pointer, intent(inout) :: link
    ! Local variables
    type(part_node_t), pointer :: child_part
    type(item_node_t), pointer :: item1, item2
 
    ! Create first child and add first item from each molecule
    child_part => new_child_part(part)
+   call link_part(link, child_part)
    call add_new_item1(child_part, part%first_item1%value)
    call add_new_item2(child_part, part%first_item2%value)
+   link%itemdir1(part%first_item1%value)%ptr => child_part
+   link%itemdir2(part%first_item2%value)%ptr => child_part
 
    ! Create second child and add remaining items
    child_part => new_child_part(part)
+   call link_part(link, child_part)
    item1 => part%first_item1%next_item
    item2 => part%first_item2%next_item
    do while (associated(item1))
       call add_new_item1(child_part, item1%value)
       call add_new_item2(child_part, item2%value)
+      link%itemdir1(item1%value)%ptr => child_part
+      link%itemdir2(item2%value)%ptr => child_part
       item1 => item1%next_item
       item2 => item2%next_item
    end do
 end subroutine
 
-function split_single_part(mnachain, split_part, branch, branch_parts) result(child_branch)
-   type(split_node_t), pointer, intent(inout) :: mnachain
+subroutine split_single_part(split_part, mnachain, leafchain, branch_parts)
    type(part_node_t), pointer, intent(inout) :: split_part
-   type(split_node_t), pointer, intent(inout) :: branch
+   type(chain_node_t), pointer, intent(inout) :: mnachain
+   type(chain_node_t), pointer, intent(inout) :: leafchain
    type(link_node_t), pointer, intent(inout) :: branch_parts
-   type(split_node_t), pointer :: child_branch
    ! Local variables
-   type(link_node_t), pointer :: chain_link, new_chain_link
-   type(link_node_t), pointer :: child_branch_link
+   type(link_node_t), pointer :: level_link, next_level_link
+   type(link_node_t), pointer :: first_leafchain_link
    type(partref_node_t), pointer :: partref
    type(part_node_t), pointer :: child_part
 
    ! Save the last link before creating a new one
-   chain_link => mnachain%last_link
-   new_chain_link => new_generic_link(mnachain)
+   level_link => mnachain%last_link
+   next_level_link => new_chain_link(mnachain)
 
-   ! Create a new child branch for this leaf part
-   child_branch => new_child_branch(branch, split_part)
-   child_branch_link => new_generic_link(child_branch)
+   ! Create a new child branch for this splitting part
+   leafchain => new_child_chain(leafchain, split_part)
+   first_leafchain_link => new_chain_link(leafchain)
 
-   ! Add non-target parts to new link
-   partref => chain_link%first_partref
+   ! Add non splitting parts to new link
+   partref => level_link%first_partref
    do while (associated(partref))
       if (.not. associated(partref%part, split_part)) then
-         call link_part(new_chain_link, partref%part)
+         call link_part(next_level_link, partref%part)
       end if
       partref => partref%nextref
    end do
 
-   ! Split target part
-   call split_part_first(split_part)
+   ! Split splitting part
+   call split_part_first(split_part, next_level_link)
 
-   ! Add target part children to links
+   ! Add part children to branch part list
    child_part => split_part%first_child_part
    do while (associated(child_part))
-      call link_part(new_chain_link, child_part)
-      call update_itemdir(new_chain_link, child_part)
-!      call update_itemdir(child_branch_link, child_part)
       call add_branch_part(branch_parts, child_part)
       child_part => child_part%next_sibling_part
    end do
-end function
+end subroutine
 
 ! Modified split_dependent_parts as a function that returns the final branch
-recursive function split_dependent_parts(mol1, mol2, mnachain, branch, fork_part, branch_parts) result(branch_tip)
+recursive subroutine split_dependent_parts(mol1, mol2, mnachain, leafchain, fork_part, branch_parts)
    type(mol_type), intent(in) :: mol1, mol2
-   type(split_node_t), pointer, intent(inout) :: mnachain
-   type(split_node_t), pointer, intent(inout) :: branch
+   type(chain_node_t), pointer, intent(inout) :: mnachain
+   type(chain_node_t), pointer, intent(inout) :: leafchain
    type(part_node_t), pointer, intent(in) :: fork_part
    type(link_node_t), pointer, intent(inout) :: branch_parts
-   type(split_node_t), pointer :: branch_tip
    ! Local variables
    type(partref_node_t), pointer :: partref
    type(part_node_t), pointer :: split_part
 
-   ! Start with the input branch
-   branch_tip => branch
-
    ! Compute consistent MNAs
-   call precompute_consistent_mnas(mol1, mol2, mnachain, branch_tip, branch_parts)
+   call precompute_consistent_mnas(mol1, mol2, mnachain, leafchain, branch_parts)
 
    ! Find a degenerate descendant part to split
    split_part => null()
@@ -218,34 +221,36 @@ recursive function split_dependent_parts(mol1, mol2, mnachain, branch, fork_part
    ! Perform split if target found
    if (associated(split_part)) then
       ! Split the target part and get the new child branch
-      branch_tip => split_single_part(mnachain, split_part, branch_tip, branch_parts)
+      call split_single_part(split_part, mnachain, leafchain, branch_parts)
       ! Call itself again to split the next degenerate descendant part
-      branch_tip => split_dependent_parts(mol1, mol2, mnachain, branch_tip, fork_part, branch_parts)
+      call split_dependent_parts(mol1, mol2, mnachain, leafchain, fork_part, branch_parts)
    end if
-end function
+end subroutine
 
 ! Updated split_independent_parts to use the new function signatures
-recursive subroutine split_independent_parts(mol1, mol2, mnachain, branch, branch_parts)
+recursive subroutine split_independent_parts(mol1, mol2, mnachain, branchain, branch_parts)
    type(mol_type), intent(in) :: mol1, mol2
-   type(split_node_t), pointer, intent(inout) :: mnachain, branch
+   type(chain_node_t), pointer, intent(inout) :: mnachain, branchain
    type(link_node_t), pointer, intent(in) :: branch_parts
    ! Local variables
    type(link_node_t), pointer :: new_branch_parts
-   type(split_node_t), pointer :: branch_tip
+   type(chain_node_t), pointer :: leafchain
    type(partref_node_t), pointer :: partref
 
    ! Process each part in branch_parts
    partref => branch_parts%first_partref
    do while (associated(partref))
       if (partref%part%num_children == 0) then
+         ! Start leaf chain from current branch chain
+         leafchain => branchain
          ! Create a new part registry for this branch part
-         new_branch_parts => new_root_link()
+         new_branch_parts => new_bare_link()
          ! Split the target part and get the new child branch
-         branch_tip => split_single_part(mnachain, partref%part, branch, new_branch_parts)
+         call split_single_part(partref%part, mnachain, leafchain, new_branch_parts)
          ! Split items for this specific part until convergence
-         branch_tip => split_dependent_parts(mol1, mol2, mnachain, branch_tip, partref%part, new_branch_parts)
+         call split_dependent_parts(mol1, mol2, mnachain, leafchain, partref%part, new_branch_parts)
          ! Recursively process the resulting branch parts
-         call split_independent_parts(mol1, mol2, mnachain, branch_tip, new_branch_parts)
+         call split_independent_parts(mol1, mol2, mnachain, leafchain, new_branch_parts)
       end if
       partref => partref%nextref
    end do

--- a/molalignlib/mna_recompute.f90
+++ b/molalignlib/mna_recompute.f90
@@ -6,11 +6,12 @@ implicit none
 
 contains
 
-subroutine resplit_part_mna(atoms1, atoms2, itemdir1, itemdir2, part)
+subroutine resplit_part_mna(atoms1, atoms2, itemdir1, itemdir2, part, link)
 ! Update item values of existing item nodes instead of adding new item nodes
    type(atom_type), dimension(:), intent(in) :: atoms1, atoms2
    type(part_nodeptr_t), dimension(:), intent(in) :: itemdir1, itemdir2
    type(part_node_t), pointer, intent(inout) :: part
+   type(link_node_t), pointer, intent(inout) :: link
    ! Local variables
    type(item_node_t), pointer :: item
    type(part_nodeptr_t), dimension(:), allocatable :: signature
@@ -39,6 +40,7 @@ subroutine resplit_part_mna(atoms1, atoms2, itemdir1, itemdir2, part)
          child_part%last_item1 => child_part%last_item1%next_item
       end if
       child_part%last_item1%value = item%value
+      link%itemdir1(item%value)%ptr => child_part
       item => item%next_item
    end do
 
@@ -57,6 +59,7 @@ subroutine resplit_part_mna(atoms1, atoms2, itemdir1, itemdir2, part)
          child_part%last_item2 => child_part%last_item2%next_item
       end if
       child_part%last_item2%value = item%value
+      link%itemdir2(item%value)%ptr => child_part
       item => item%next_item
    end do
 end subroutine
@@ -67,19 +70,13 @@ subroutine recompute_nextlevel_mnas(mol1, mol2, link)
    type(link_node_t), pointer, intent(inout) :: link
    ! Local variables
    type(partref_node_t), pointer :: partref
-   type(part_node_t), pointer :: child_part
 
    ! Process all parts in the current partition
    partref => link%first_partref
    do while (associated(partref))
 !      write (stderr,'(A,1X,A)') 'Part', address(partref%part)
       ! Distribute items based on signatures
-      call resplit_part_mna(mol1%atoms, mol2%atoms, link%itemdir1, link%itemdir2, partref%part)
-      child_part => partref%part%first_child_part
-      do while (associated(child_part))
-         call update_itemdir(link%next_link, child_part)
-         child_part => child_part%next_sibling_part
-      end do
+      call resplit_part_mna(mol1%atoms, mol2%atoms, link%itemdir1, link%itemdir2, partref%part, link%next_link)
       partref => partref%nextref
    end do
 end subroutine
@@ -87,7 +84,7 @@ end subroutine
 subroutine recompute_consistent_mnas(mol1, mol2, branch)
 ! Iteratively compute MNA types until convergence
    type(mol_type), intent(in) :: mol1, mol2
-   type(split_node_t), pointer, intent(inout) :: branch
+   type(chain_node_t), pointer, intent(inout) :: branch
    ! Local variables
    type(link_node_t), pointer :: link
    integer link_idx
@@ -104,39 +101,48 @@ subroutine recompute_consistent_mnas(mol1, mol2, branch)
    end do
 end subroutine
 
-subroutine resplit_part_first(part)
+subroutine resplit_part_first(part, link)
    type(part_node_t), pointer, intent(inout) :: part
+   type(link_node_t), pointer, intent(inout) :: link
    ! Local variables
    type(part_node_t), pointer :: child_part
    type(item_node_t), pointer :: item1, item2
 
    ! Add first item to first child
    child_part => part%first_child_part
-   child_part%first_item1%value = part%first_item1%value
-   child_part%first_item2%value = part%first_item2%value
-
-   ! Add second item to second child
-   child_part => part%first_child_part%next_sibling_part
-   child_part%first_item1%value = part%first_item1%next_item%value
-   child_part%first_item2%value = part%first_item2%next_item%value
+   item1 => part%first_item1
+   item2 => part%first_item2
+   child_part%first_item1%value = item1%value
+   child_part%first_item2%value = item2%value
+   link%itemdir1(item1%value)%ptr => child_part
+   link%itemdir2(item2%value)%ptr => child_part
 
    ! Add remaining items to second child
-   item1 => part%first_item1%next_item%next_item
-   item2 => part%first_item2%next_item%next_item
-   child_part%last_item1 => child_part%first_item1
-   child_part%last_item2 => child_part%first_item2
+   child_part => child_part%next_sibling_part
+   child_part%last_item1 => null()
+   child_part%last_item2 => null()
+   item1 => item1%next_item
+   item2 => item2%next_item
    do while (associated(item1))
-      child_part%last_item1 => child_part%last_item1%next_item
-      child_part%last_item2 => child_part%last_item2%next_item
+      if (.not. associated(child_part%last_item1)) then
+         child_part%last_item1 => child_part%first_item1
+         child_part%last_item2 => child_part%first_item2
+      else
+         child_part%last_item1 => child_part%last_item1%next_item
+         child_part%last_item2 => child_part%last_item2%next_item
+      end if
       child_part%last_item1%value = item1%value
       child_part%last_item2%value = item2%value
+      link%itemdir1(item1%value)%ptr => child_part
+      link%itemdir2(item2%value)%ptr => child_part
       item1 => item1%next_item
       item2 => item2%next_item
    end do
 end subroutine
 
-subroutine resplit_part_random(part)
+subroutine resplit_part_random(part, link)
    type(part_node_t), pointer, intent(inout) :: part
+   type(link_node_t), pointer, intent(inout) :: link
    ! Local variables
    type(part_node_t), pointer :: child_part1, child_part2
    type(item_node_t), pointer :: item1, item2
@@ -168,6 +174,7 @@ subroutine resplit_part_random(part)
       current_index = current_index + 1
    end do
    child_part1%first_item1%value = item1%value
+   link%itemdir1(item1%value)%ptr => child_part1
 
    ! Find and assign the random item from items2 to first child
    item2 => part%first_item2
@@ -177,23 +184,26 @@ subroutine resplit_part_random(part)
       current_index = current_index + 1
    end do
    child_part1%first_item2%value = item2%value
+   link%itemdir2(item2%value)%ptr => child_part1
 
    write (stderr,*) address(part), item1%value, item2%value
 
    ! Now assign all other items from items1 to second child
    item1 => part%first_item1
    current_index = 1
-   child_part2%last_item1 => child_part2%first_item1
+   child_part2%last_item1 => null()
 
    do while (associated(item1))
       if (current_index /= random_index1) then
-         ! This is not the random item, assign to second child
-         child_part2%last_item1%value = item1%value
-
-         ! Move to next position in second child (if not the last item)
-         if (associated(child_part2%last_item1%next_item)) then
+         ! Move to next position in second child
+         if (.not. associated(child_part2%last_item1)) then
+            child_part2%last_item1 => child_part2%first_item1
+         else
             child_part2%last_item1 => child_part2%last_item1%next_item
          end if
+         ! This is not the random item, assign to second child
+         child_part2%last_item1%value = item1%value
+         link%itemdir1(item1%value)%ptr => child_part2
       end if
 
       ! Move to next item in parent
@@ -204,17 +214,19 @@ subroutine resplit_part_random(part)
    ! Now assign all other items from items2 to second child
    item2 => part%first_item2
    current_index = 1
-   child_part2%last_item2 => child_part2%first_item2
+   child_part2%last_item2 => null()
 
    do while (associated(item2))
       if (current_index /= random_index2) then
-         ! This is not the random item, assign to second child
-         child_part2%last_item2%value = item2%value
-
-         ! Move to next position in second child (if not the last item)
-         if (associated(child_part2%last_item2%next_item)) then
+         ! Move to next position in second child
+         if (.not. associated(child_part2%last_item2)) then
+            child_part2%last_item2 => child_part2%first_item2
+         else
             child_part2%last_item2 => child_part2%last_item2%next_item
          end if
+         ! This is not the random item, assign to second child
+         child_part2%last_item2%value = item2%value
+         link%itemdir2(item2%value)%ptr => child_part2
       end if
 
       ! Move to next item in parent
@@ -225,31 +237,27 @@ end subroutine
 
 recursive subroutine redistribute_items(mol1, mol2, branch)
    type(mol_type), intent(in) :: mol1, mol2
-   type(split_node_t), pointer, intent(inout) :: branch
-   type(split_node_t), pointer :: child_branch
+   type(chain_node_t), pointer, intent(inout) :: branch
+   type(chain_node_t), pointer :: child_branch
    type(part_node_t), pointer :: child_part
 
    ! Process all children of this branch
-   child_branch => branch%first_child_branch
+   child_branch => branch%first_child_chain
    do while (associated(child_branch))
       ! Process this child branch's split_part
 !      write (stderr,*)
 !      write (stderr,'(A,1X,A)') 'Split Part', address(child_branch%split_part)
-!      call resplit_part_first(child_branch%split_part)
-      call resplit_part_random(child_branch%split_part)
+!      call resplit_part_first(child_branch%split_part, child_branch%first_link)
+      call resplit_part_random(child_branch%split_part, child_branch%first_link)
       ! Add target part children to links
       child_part => child_branch%split_part%first_child_part
-      do while (associated(child_part))
-         call update_itemdir(child_branch%first_link, child_part)
-         child_part => child_part%next_sibling_part
-      end do
       call recompute_consistent_mnas(mol1, mol2, child_branch)
 
       ! Recursively process this child's descendants (depth-first)
       call redistribute_items(mol1, mol2, child_branch)
 
       ! Move to next sibling
-      child_branch => child_branch%next_sibling_branch
+      child_branch => child_branch%next_sibling_chain
    end do
 end subroutine
 

--- a/molalignlib/pruning.f90
+++ b/molalignlib/pruning.f90
@@ -33,7 +33,7 @@ abstract interface
       use basetypes
       use molecule
       use lcrs_tree
-      type(partitionarray_t), intent(in) :: eltypes
+      type(partition_t), intent(in) :: eltypes
       type(mol_type), intent(in) :: mol1, mol2
       type(bool_matrix), dimension(:), allocatable, intent(out) :: prunes
    end subroutine
@@ -42,7 +42,7 @@ end interface
 contains
 
 subroutine prune_none( eltypes, mol1, mol2, prunes)
-   type(partitionarray_t), intent(in) :: eltypes
+   type(partition_t), intent(in) :: eltypes
    type(mol_type), intent(in) :: mol1, mol2
    type(bool_matrix), dimension(:), allocatable, intent(out) :: prunes
    ! Local variables
@@ -64,7 +64,7 @@ subroutine prune_none( eltypes, mol1, mol2, prunes)
 end subroutine
 
 subroutine prune_rd( eltypes, mol1, mol2, prunes)
-   type(partitionarray_t), intent(in) :: eltypes
+   type(partition_t), intent(in) :: eltypes
    type(mol_type), intent(in) :: mol1, mol2
    type(bool_matrix), dimension(:), allocatable, intent(out) :: prunes
    ! Local variables

--- a/molalignlib/reactivity.f90
+++ b/molalignlib/reactivity.f90
@@ -37,13 +37,13 @@ contains
 
 subroutine find_reactive_bonds( mol1, mol2, eltypes, atomperm)
    type(mol_type), intent(in) :: mol1, mol2
-   type(partitionarray_t), intent(in) :: eltypes
+   type(partition_t), intent(in) :: eltypes
    integer, dimension(:), intent(out) :: atomperm
 
    ! Local variables
-   type(partitionarray_t) :: mnatypes
+   type(partition_t) :: mnatypes
    type(part_node_t), pointer :: root_part
-   type(split_node_t), pointer :: mnachain
+   type(chain_node_t), pointer :: mnachain
    type(int_list), dimension(:), allocatable :: molfrags1, molfrags2
    type(int_matrix), dimension(:), allocatable :: biases
    type(topoatomperm_registry), target :: results
@@ -78,9 +78,9 @@ subroutine find_reactive_bonds( mol1, mol2, eltypes, atomperm)
    call translate_coords( coords2, center1)
 
    ! Compute MNA types
-   call init_chain_from_partarray( eltypes, mnachain, root_part)
+   call init_chain_from_partition( eltypes, mnachain, root_part)
    call compute_consistent_mnas( mol1, mol2, mnachain)
-   call partition_to_partitionarray( mnachain%last_link, mnatypes)
+   call link_to_partition( mnachain%last_link, mnatypes)
 
    ! Find molecular fragments
    call find_molfrags( mol1, first_partition(eltypes), molfrags1)
@@ -113,7 +113,7 @@ end subroutine
 subroutine remove_reactive_bonds( mol1, mol2, eltypes, atomperm)
    ! Remove reactive bonds
    type(mol_type), intent(inout) :: mol1, mol2
-   type(partitionarray_t), intent(in) :: eltypes
+   type(partition_t), intent(in) :: eltypes
    integer, dimension(:), intent(in) :: atomperm
    ! Local variables
    logical, dimension(:,:), allocatable :: adjmat1, adjmat2

--- a/molalignlib/remapping_bonded.f90
+++ b/molalignlib/remapping_bonded.f90
@@ -44,7 +44,7 @@ subroutine remap_bonded_atoms(mol1, mol2, results)
    type(bondatomperm_registry), target, intent(out) :: results
 
    ! Local variables
-   type(partitionarray_t) :: eltypes
+   type(partition_t) :: eltypes
    logical, dimension(:,:), allocatable :: adjmat1, adjmat2
    integer, dimension(:), allocatable :: atomperm, auxperm
    integer, dimension(:), allocatable :: elnums1, elnums2
@@ -151,10 +151,10 @@ end subroutine
 
 subroutine assign_conform_atoms( mol1, mol2, eltypes)
    type(mol_type), intent(in) :: mol1, mol2
-   type(partitionarray_t), intent(in) :: eltypes
+   type(partition_t), intent(in) :: eltypes
    ! Local variables
    type(part_node_t), pointer :: root_part, temp_part
-   type(split_node_t), pointer :: mnachain, temp_chain, root_branch
+   type(chain_node_t), pointer :: mnachain2, mnachain1, chain_tree
    type(link_node_t), pointer :: branch_parts
    type(part_node_t), pointer :: child_part
    integer unit1, unit2
@@ -167,38 +167,37 @@ subroutine assign_conform_atoms( mol1, mol2, eltypes)
 !   call print_atoms( mol1)
 !   call print_atoms( mol2)
 
-!   call init_chain_from_partarray( eltypes, mnachain, root_part)
-!   root_branch => new_root_branch( mnachain%tot_items1, mnachain%tot_items2)
-!   leaf_link => new_generic_link( root_branch)
+!   call init_chain_from_partition( eltypes, mnachain2, root_part)
+!   chain_tree => new_root_chain( mnachain2%tot_items1, mnachain2%tot_items2)
+!   leaf_link => new_chain_link( chain_tree)
 !   call update_itemdir_children( leaf_link, root_part)
-!   branch_parts => new_root_link()
+!   branch_parts => new_bare_link()
 !   call update_branch_parts(branch_parts, root_part)
-!   call precompute_consistent_mnas(mol1, mol2, mnachain, root_branch, branch_parts)
+!   call precompute_consistent_mnas(mol1, mol2, mnachain2, chain_tree, branch_parts)
 
-   call init_chain_from_partarray( eltypes, temp_chain, temp_part)
-   call compute_consistent_mnas( mol1, mol2, temp_chain)
-   call init_chain_from_link( temp_chain%last_link, mnachain, root_part)
+   call init_chain_from_partition( eltypes, mnachain1, temp_part)
+   call compute_consistent_mnas( mol1, mol2, mnachain1)
+   call init_chain_from_link( mnachain1%last_link, mnachain2, root_part)
    call print_tree_items( root_part)
 
-   root_branch => new_root_branch( mnachain%tot_items1, mnachain%tot_items2)
-   branch_parts => new_root_link()
+   chain_tree => new_root_chain( mnachain2%tot_items1, mnachain2%tot_items2)
+   branch_parts => new_bare_link()
    child_part => root_part%first_child_part
    do while (associated(child_part))
       call add_branch_part(branch_parts, child_part)
       child_part => child_part%next_sibling_part
    end do
 
-   call split_independent_parts( mol1, mol2, mnachain, root_branch, branch_parts)
+   call split_independent_parts( mol1, mol2, mnachain2, chain_tree, branch_parts)
    call print_part_tree( root_part)
-!   call print_tree_items( root_part)
+!   call print_part_indices( root_part)
+!   call print_chain_indices( chain_tree)
 
 !   call print_tree_signatures( root_part)
-   call print_split_tree( root_branch)
-!   call print_chain( mnachain)
-!   call print_chain( root_branch%first_child_branch)
+   call print_chain_tree( chain_tree)
 
-   call random_init(.false., .true.)
-   call redistribute_items( mol1, mol2, root_branch)
+   call random_init(.true., .true.)
+   call redistribute_items( mol1, mol2, chain_tree)
    call print_leaf_items( root_part)
 end subroutine
 

--- a/molalignlib/remapping_free.f90
+++ b/molalignlib/remapping_free.f90
@@ -37,7 +37,7 @@ subroutine remap_free_atoms(mol1, mol2, results)
    type(atomperm_registry), intent(out) :: results
 
    ! Local variables
-   type(partitionarray_t) :: eltypes
+   type(partition_t) :: eltypes
    type(bool_matrix), dimension(:), allocatable :: prunes
    integer :: num_steps
    integer, dimension(:), allocatable :: atomperm, auxperm

--- a/molalignlib/tracking.f90
+++ b/molalignlib/tracking.f90
@@ -22,7 +22,7 @@ contains
 
 subroutine find_molfrags( mol, eltypes, molfrags)
    type(mol_type), intent(in) :: mol
-   type(semipartitionarray_t), intent(in) :: eltypes
+   type(semipartition_t), intent(in) :: eltypes
    type(int_list), dimension(:), allocatable, intent(out) :: molfrags
    ! Local variables
    integer :: i, nfrag
@@ -98,7 +98,7 @@ subroutine minadjdiff( eltypes, mnatypes, molfrags, mol1, mol2, coords1, &
 !
 
    ! Arguments
-   type(partitionarray_t), intent(in) :: eltypes, mnatypes
+   type(partition_t), intent(in) :: eltypes, mnatypes
    type(int_list), dimension(:), intent(in) :: molfrags
    type(mol_type), intent(in) :: mol1, mol2
    real(rk), dimension(:,:), intent(in) :: coords1, coords2


### PR DESCRIPTION
Add global indices to part_node_t, item_node_t, chain_node_t, link_node_t and partref_node_t Add counters for total parts, items, chains, links and partrefs Clean up mna_precompute_module and mna_recompute_module Rename derived types and variables